### PR TITLE
Re-organizing makefile; Adding LDFLAGS variable; Not needed targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.DEFAULT_GOAL := all
+###############################################################################
+# Global variables
 
 PROGRAM_NAME        = 2DpartInt
 SRC_C_DIR           = src/c
@@ -9,44 +10,56 @@ INC_DIR             = include
 TEST_DIR            = test
 CC                  = gcc
 CXX                 = g++
-CFLAGS              = 
+CFLAGS              =
 ALL_CFLAGS          = -std=c11 -O3 -Wall -Wextra -Werror $(CFLAGS)
+LDFLAGS		    = -lm
 RM                  = rm -rf
 MKDIR               = mkdir -p
 
-$(BUILD_DIR)/functions.o: $(SRC_C_DIR)/functions.c $(INC_DIR)/data.h $(INC_DIR)/functions.h
-	$(MKDIR) $(BUILD_DIR)
-	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
+###############################################################################
+# Main program compilation
 
-$(BUILD_DIR)/functions_spec.o: $(TEST_DIR)/functions_spec.c $(INC_DIR)/data.h $(INC_DIR)/functions.h
-	$(MKDIR) $(BUILD_DIR)
-	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
-
-$(BIN_DIR)/functions_spec: $(BUILD_DIR)/functions.o $(BUILD_DIR)/functions_spec.o
-	$(MKDIR) $(BIN_DIR)
-	$(CC) $(ALL_CFLAGS) -o $@ $^ -lm
-
-.PHONY: functions_spec
-functions_spec: $(BIN_DIR)/functions_spec
-	$(BIN_DIR)/functions_spec
-
-.PHONY: test
-test: functions_spec
-
-$(BUILD_DIR)/main.o: $(SRC_C_DIR)/main.c $(INC_DIR)/data.h $(INC_DIR)/functions.h
-	$(MKDIR) $(BUILD_DIR)
-	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
-
-$(BIN_DIR)/$(PROGRAM_NAME): $(BUILD_DIR)/functions.o $(BUILD_DIR)/main.o
-	$(MKDIR) $(BIN_DIR)
-	$(CC) $(ALL_CFLAGS) -o $@ $^ -lm
+.DEFAULT_GOAL := all
 
 .PHONY: all
 all: $(BIN_DIR)/$(PROGRAM_NAME)
 
+$(BIN_DIR)/$(PROGRAM_NAME): $(BUILD_DIR)/functions.o $(BUILD_DIR)/main.o
+	$(MKDIR) $(BIN_DIR)
+	$(CC) $(ALL_CFLAGS) -o $@ $^ $(LDFLAGS)
+
+$(BUILD_DIR)/functions.o: $(SRC_C_DIR)/functions.c
+	$(MKDIR) $(BUILD_DIR)
+	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
+
+$(BUILD_DIR)/main.o: $(SRC_C_DIR)/main.c
+	$(MKDIR) $(BUILD_DIR)
+	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
+
+###############################################################################
+# Tests
+
+.PHONY: test
+test: $(BIN_DIR)/functions_spec
+	$(BIN_DIR)/functions_spec
+
+$(BIN_DIR)/functions_spec: $(BUILD_DIR)/functions.o $(BUILD_DIR)/functions_spec.o
+	$(MKDIR) $(BIN_DIR)
+	$(CC) $(ALL_CFLAGS) -o $@ $^ $(LDFLAGS)
+
+$(BUILD_DIR)/functions_spec.o: $(TEST_DIR)/functions_spec.c
+	$(MKDIR) $(BUILD_DIR)
+	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
+
+###############################################################################
+# Run
+
 .PHONY: run
 run: all
 	$(BIN_DIR)/$(PROGRAM_NAME)
+
+###############################################################################
+# Clean
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ $(BIN_DIR)/$(PROGRAM_NAME): $(BUILD_DIR)/functions.o $(BUILD_DIR)/main.o
 	$(MKDIR) $(BIN_DIR)
 	$(CC) $(ALL_CFLAGS) -o $@ $^ $(LDFLAGS)
 
-$(BUILD_DIR)/functions.o: $(SRC_C_DIR)/functions.c
+$(BUILD_DIR)/functions.o: $(SRC_C_DIR)/functions.c $(INC_DIR)/data.h $(INC_DIR)/functions.h
 	$(MKDIR) $(BUILD_DIR)
 	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
 
-$(BUILD_DIR)/main.o: $(SRC_C_DIR)/main.c
+$(BUILD_DIR)/main.o: $(SRC_C_DIR)/main.c $(INC_DIR)/data.h $(INC_DIR)/functions.h
 	$(MKDIR) $(BUILD_DIR)
 	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
 
@@ -47,7 +47,7 @@ $(BIN_DIR)/functions_spec: $(BUILD_DIR)/functions.o $(BUILD_DIR)/functions_spec.
 	$(MKDIR) $(BIN_DIR)
 	$(CC) $(ALL_CFLAGS) -o $@ $^ $(LDFLAGS)
 
-$(BUILD_DIR)/functions_spec.o: $(TEST_DIR)/functions_spec.c
+$(BUILD_DIR)/functions_spec.o: $(TEST_DIR)/functions_spec.c $(INC_DIR)/data.h $(INC_DIR)/functions.h
 	$(MKDIR) $(BUILD_DIR)
 	$(CC) $(ALL_CFLAGS) -I$(INC_DIR) -o $@ -c $<
 


### PR DESCRIPTION
Re-organizing the structure of the makefile so it is easier to read and understand. Also, there where some targets when creating the object files (main.o, functions.o, ...), such as, $(INC_DIR)/data.h $(INC_DIR)/functions.h, which are not needed. The compiler flag -I/include/dir makes the job of including them. In fact, the $< directive in makefiles is to use only the first dependency listed not all the depencies. Therefore, I don't understand why the the other dependencies were there if there were not being used. Also, I added the LDFLAGS variable, which is part of makefiles standards. This variable will help us to link other libraries easier in the future, see https://www2.cs.duke.edu/courses/cps108/doc/makefileinfo/sample.html for more information.