### PR TITLE
Commented tests code

### DIFF
--- a/test/functions_spec.c
+++ b/test/functions_spec.c
@@ -251,22 +251,23 @@ void test_compute_velocity_one_element() {
 /**
  * Checks that the compute_velocity function works for arrays of multiple elements.
  */
-//void test_compute_velocity_multiple_elements() {
-//  #define size 3
-//  Vector acceleration[size] = { { -10.59, 162.35 }, { , }, { , } };
-//  double dt = 0.00025;
-//  Vector velocities[size] = { { 5, 2 }, { , }, { , } };
-//  Vector resultant_velocity[size] = { { 0 } };
-//
-//  compute_velocity(size, acceleration, dt, velocities, resultant_velocity);
-//
-//  Vector expected[size] = { { -34.2779d, -43.31335149863761d }, { 3.5152508192588856d, -50.6241d }, { -1045.4231d, -1.1923d } };
-//  for (size_t i = 0; i < size; ++i) {
-//    for_assert(resultant_velocity[i].x_component, expected[i].x_component, "test_compute_velocity_multiple_elements - x_component", i);
-//    for_assert(resultant_velocity[i].y_component, expected[i].y_component, "test_compute_velocity_multiple_elements - y_component", i);
-//  }
-//  #undef size
-//}
+void test_compute_velocity_multiple_elements() {
+  #define size 3
+  Vector accelerations[size] = { { -10.59, 162.35 }, { -53223.12, 4212.124}, { 532521.2124124, 12142.512124} };
+  double dt = 0.00025;
+  Vector velocities[size] = { { 5.332, 2.123 }, { 7.12, 8.96}, { 61.52, 1293.123} };
+
+  compute_velocity(dt, 0, accelerations, velocities);
+  compute_velocity(dt, 1, accelerations, velocities);
+  compute_velocity(dt, 2, accelerations, velocities);
+
+  Vector expected[size] = { { 5.3293525d, 2.1635875d }, { -6.18578d, 10.013031d }, { 194.6503031031d, 1296.158628031d } };
+  for (size_t i = 0; i < size; ++i) {
+    for_assert(velocities[i].x_component, expected[i].x_component, "test_compute_velocity_multiple_elements - x_component", i);
+    for_assert(velocities[i].y_component, expected[i].y_component, "test_compute_velocity_multiple_elements - y_component", i);
+  }
+  #undef size
+}
 
 /**
  * Checks that the displace_particles function works for arrays of one element.
@@ -318,7 +319,7 @@ int main(void) {
   test_compute_acceleration_one_element();
   test_compute_acceleration_multiple_elements();
   test_compute_velocity_one_element();
-  //test_compute_velocity_multiple_elements();
+  test_compute_velocity_multiple_elements();
   test_displace_particles_one_element();
   test_displace_particles_multiple_elements();
 

--- a/test/functions_spec.c
+++ b/test/functions_spec.c
@@ -235,19 +235,18 @@ void test_compute_acceleration_multiple_elements() {
 /**
  * Checks that the compute_velocity function works for arrays of one element.
  */
-//void test_compute_velocity_one_element() {
-//  #define size 1
-//  Vector acceleration[size] = { { 42.53, -631.431 } };
-//  double dt = 0.00025;
-//  Vector velocities[size] = { { 0, 0 } };
-//  Vector resultant_velocity[size] = { { 0 } };
-//
-//  compute_velocity(size, acceleration, dt, velocities, resultant_velocity);
-//
-//  assert(resultant_velocity[0].x_component, 0.010632500000000001d, "test_compute_velocity_one_element - x_component");
-//  assert(resultant_velocity[0].y_component, -0.15785775000000002d, "test_compute_velocity_one_element - y_component");
-//  #undef size
-//}
+void test_compute_velocity_one_element() {
+  #define size 1
+  Vector accelerations[size] = { { 42.53, -631.431 } };
+  double dt = 0.00025;
+  Vector velocities[size] = { { 0, 0 } };
+
+  compute_velocity(dt, 0, accelerations, velocities);
+
+  assert(velocities[0].x_component, 0.010632500000000001d, "test_compute_velocity_one_element - x_component");
+  assert(velocities[0].y_component, -0.15785775000000002d, "test_compute_velocity_one_element - y_component");
+  #undef size
+}
 
 /**
  * Checks that the compute_velocity function works for arrays of multiple elements.
@@ -318,7 +317,7 @@ int main(void) {
   test_compute_forces_multiple_contacts();
   test_compute_acceleration_one_element();
   test_compute_acceleration_multiple_elements();
-  //test_compute_velocity_one_element();
+  test_compute_velocity_one_element();
   //test_compute_velocity_multiple_elements();
   test_displace_particles_one_element();
   test_displace_particles_multiple_elements();


### PR DESCRIPTION
Uncommented the code. Tests now working. It was commented at first because the interface for `compute_velocity` had changed, so the tests would not work until they were updated appropriately. 